### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ meters - Yet another metrics library
 ===========================
 [![Build Status](https://travis-ci.org/yandex-sysmon/meters.svg?branch=master)](https://travis-ci.org/yandex-sysmon/meters)
 [![Coverage Status](https://coveralls.io/repos/yandex-sysmon/meters/badge.png)](https://coveralls.io/r/yandex-sysmon/meters)
-[![Latest Version](https://pypip.in/v/meters/badge.png)](https://pypi.python.org/pypi/meters/)
+[![Latest Version](https://img.shields.io/pypi/v/meters.svg)](https://pypi.python.org/pypi/meters/)
 
 Tracks server state and statistics, allowing you to see what your server is
 doing. It can also send metrics to Graphite for graphing or to a file for crash forensics.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20meters))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `meters`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.